### PR TITLE
Add block begin / end subscription types

### DIFF
--- a/state/execution.go
+++ b/state/execution.go
@@ -475,6 +475,10 @@ func fireEvents(
 	abciResponses *tmstate.ABCIResponses,
 	validatorUpdates []*types.Validator,
 ) {
+	if err := eventBus.PublishBeginBlock(block.Height); err != nil {
+		logger.Error("failed publishing block start", "err", err)
+	}
+
 	if err := eventBus.PublishEventNewBlock(types.EventDataNewBlock{
 		Block:            block,
 		ResultBeginBlock: *abciResponses.BeginBlock,
@@ -519,6 +523,10 @@ func fireEvents(
 			types.EventDataValidatorSetUpdates{ValidatorUpdates: validatorUpdates}); err != nil {
 			logger.Error("failed publishing event", "err", err)
 		}
+	}
+
+	if err := eventBus.PublishEndBlock(block.Height); err != nil {
+		logger.Error("failed publishing block end", "err", err)
 	}
 }
 

--- a/types/event_bus.go
+++ b/types/event_bus.go
@@ -131,6 +131,14 @@ func (b *EventBus) validateAndStringifyEvents(events []types.Event, logger log.L
 	return result
 }
 
+func (b *EventBus) PublishBeginBlock(height int64) error {
+	return b.Publish(EventBlockBegin, height)
+}
+
+func (b *EventBus) PublishEndBlock(height int64) error {
+	return b.Publish(EventBlockEnd, height)
+}
+
 func (b *EventBus) PublishEventNewBlock(data EventDataNewBlock) error {
 	// no explicit deadline for publishing events
 	ctx := context.Background()
@@ -236,6 +244,14 @@ func (NopEventBus) Subscribe(
 	query tmpubsub.Query,
 	out chan<- interface{},
 ) error {
+	return nil
+}
+
+func (NopEventBus) PublishBeginBlock(height int64) error {
+	return nil
+}
+
+func (NopEventBus) PublishEndBlock(height int64) error {
 	return nil
 }
 

--- a/types/events.go
+++ b/types/events.go
@@ -22,6 +22,10 @@ const (
 	EventTx                  = "Tx"
 	EventValidatorSetUpdates = "ValidatorSetUpdates"
 
+	// Frame bounds
+	EventBlockBegin = "BlockBegin"
+	EventBlockEnd   = "BlockEnd"
+
 	// Internal consensus events.
 	// These are used for testing the consensus state machine.
 	// They can also be used to build real-time consensus visualizers.
@@ -143,6 +147,8 @@ const (
 )
 
 var (
+	EventQueryBlockBegin          = QueryForEvent(EventBlockBegin)
+	EventQueryBlockEnd            = QueryForEvent(EventBlockEnd)
 	EventQueryCompleteProposal    = QueryForEvent(EventCompleteProposal)
 	EventQueryLock                = QueryForEvent(EventLock)
 	EventQueryNewBlock            = QueryForEvent(EventNewBlock)
@@ -171,6 +177,9 @@ func QueryForEvent(eventType string) tmpubsub.Query {
 
 // BlockEventPublisher publishes all block related events
 type BlockEventPublisher interface {
+	PublishBeginBlock(int64) error
+	PublishEndBlock(int64) error
+
 	PublishEventNewBlock(block EventDataNewBlock) error
 	PublishEventNewBlockHeader(header EventDataNewBlockHeader) error
 	PublishEventNewEvidence(evidence EventDataNewEvidence) error


### PR DESCRIPTION
Regular event subscriptions dont tells us when block data for a single height is complete.